### PR TITLE
dbeaver/dbeaver-jdbc-libsql#17 Added libsql urls support

### DIFF
--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
@@ -20,8 +20,9 @@ import java.util.regex.Pattern;
 
 public class LibSqlConstants {
 
-    public static final Pattern CONNECTION_URL_EXAMPLE = Pattern.compile("jdbc:dbeaver:libsql:<server-url>");
-    public static final Pattern CONNECTION_URL_PATTERN = Pattern.compile("jdbc:dbeaver:libsql:(.+)");
+    public static final String CONNECTION_URL_EXAMPLES = "jdbc:dbeaver:libsql:<hostname>, libsql://<hostname>";
+    public static final String CONNECTION_PROTOCOLS_REGEXP = "jdbc:dbeaver:libsql:|libsql://";
+    public static final Pattern CONNECTION_URL_PATTERN = Pattern.compile("(" + CONNECTION_PROTOCOLS_REGEXP + ")(.+)");
 
     public static final int DRIVER_VERSION_MAJOR = 1;
     public static final int DRIVER_VERSION_MINOR = 0;

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDriver.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDriver.java
@@ -46,9 +46,10 @@ public class LibSqlDriver implements Driver {
         if (!matcher.matches()) {
             throw new LibSqlException(
                 "Invalid connection URL: " + url +
-                ".\nExpected URL format: " + LibSqlConstants.CONNECTION_URL_EXAMPLE);
+                ".\nExpected URL formats: " + LibSqlConstants.CONNECTION_URL_EXAMPLES);
         }
-        String targetUrl = matcher.group(1);
+        String targetUrl = matcher.group(0)
+            .replaceAll(LibSqlConstants.CONNECTION_PROTOCOLS_REGEXP, "https://");
 
         Map<String, Object> props = new LinkedHashMap<>();
         for (Enumeration<?> pne = info.propertyNames(); pne.hasMoreElements(); ) {


### PR DESCRIPTION
* Added support for Turso's libsql urls.
* Fixed existing `jdbc:dbeaver:libsql` URLs suport.

