### PR TITLE
dbeaver/dbeaver#38710 fixed non-turso hostnames+ports

### DIFF
--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
@@ -21,9 +21,9 @@ import java.util.regex.Pattern;
 public class LibSqlConstants {
 
     public static final String CONNECTION_URL_EXAMPLES = "jdbc:dbeaver:libsql:<hostname>, libsql://<hostname>";
-    public static final String CONNECTION_PROTOCOLS_REGEXP = "jdbc:dbeaver:libsql:(https://)?(libsql://)?|libsql://";
+    public static final String CONNECTION_PROTOCOLS_REGEXP = "jdbc:dbeaver:libsql:(http(s)?://)?(libsql://)?|libsql://";
     public static final Pattern CONNECTION_URL_PATTERN =
-        Pattern.compile("(" + CONNECTION_PROTOCOLS_REGEXP + ")[a-z0-9.-]+");
+        Pattern.compile("(" + CONNECTION_PROTOCOLS_REGEXP + ")[a-z0-9:.-]+");
 
     public static final int DRIVER_VERSION_MAJOR = 1;
     public static final int DRIVER_VERSION_MINOR = 0;

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
@@ -21,9 +21,8 @@ import java.util.regex.Pattern;
 public class LibSqlConstants {
 
     public static final String CONNECTION_URL_EXAMPLES = "jdbc:dbeaver:libsql:<hostname>, libsql://<hostname>";
-    public static final String CONNECTION_PROTOCOLS_REGEXP = "jdbc:dbeaver:libsql:(http(s)?://)?(libsql://)?|libsql://";
     public static final Pattern CONNECTION_URL_PATTERN =
-        Pattern.compile("(" + CONNECTION_PROTOCOLS_REGEXP + ")[a-z0-9:.-]+");
+        Pattern.compile("(jdbc:dbeaver:libsql:)?(libsql://)?[a-z0-9/:.-]+");
 
     public static final int DRIVER_VERSION_MAJOR = 1;
     public static final int DRIVER_VERSION_MINOR = 0;

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
@@ -22,7 +22,7 @@ public class LibSqlConstants {
 
     public static final String CONNECTION_URL_EXAMPLES = "jdbc:dbeaver:libsql:<hostname>, libsql://<hostname>";
     public static final Pattern CONNECTION_URL_PATTERN =
-        Pattern.compile("(jdbc:dbeaver:libsql:|libsql://)[a-z0-9/:.-]+");
+        Pattern.compile("(jdbc:dbeaver:libsql:|libsql://).*");
 
     public static final int DRIVER_VERSION_MAJOR = 1;
     public static final int DRIVER_VERSION_MINOR = 0;

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
@@ -22,7 +22,7 @@ public class LibSqlConstants {
 
     public static final String CONNECTION_URL_EXAMPLES = "jdbc:dbeaver:libsql:<hostname>, libsql://<hostname>";
     public static final Pattern CONNECTION_URL_PATTERN =
-        Pattern.compile("(jdbc:dbeaver:libsql:)?(libsql://)?[a-z0-9/:.-]+");
+        Pattern.compile("(jdbc:dbeaver:libsql:|libsql://)[a-z0-9/:.-]+");
 
     public static final int DRIVER_VERSION_MAJOR = 1;
     public static final int DRIVER_VERSION_MINOR = 0;

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDriver.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDriver.java
@@ -48,8 +48,12 @@ public class LibSqlDriver implements Driver {
                 "Invalid connection URL: " + url +
                 ".\nExpected URL formats: " + LibSqlConstants.CONNECTION_URL_EXAMPLES);
         }
-        String targetUrl = matcher.group(0)
-            .replaceAll(LibSqlConstants.CONNECTION_PROTOCOLS_REGEXP, "https://");
+
+        String targetUrl = url.replace("jdbc:dbeaver:libsql:", "");
+        if (!targetUrl.startsWith("http")) {
+            targetUrl = matcher.group(0)
+                .replaceAll(LibSqlConstants.CONNECTION_PROTOCOLS_REGEXP, "https://");
+        }
 
         Map<String, Object> props = new LinkedHashMap<>();
         for (Enumeration<?> pne = info.propertyNames(); pne.hasMoreElements(); ) {

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDriver.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDriver.java
@@ -49,10 +49,9 @@ public class LibSqlDriver implements Driver {
                 ".\nExpected URL formats: " + LibSqlConstants.CONNECTION_URL_EXAMPLES);
         }
 
-        String targetUrl = url.replace("jdbc:dbeaver:libsql:", "");
-        if (!targetUrl.startsWith("http")) {
-            targetUrl = matcher.group(0)
-                .replaceAll(LibSqlConstants.CONNECTION_PROTOCOLS_REGEXP, "https://");
+        String targetUrl = url.replaceFirst("jdbc:dbeaver:libsql:", "");
+        if (targetUrl.startsWith("libsql://")) {
+            targetUrl = targetUrl.replaceFirst("libsql://", "https://");
         }
 
         Map<String, Object> props = new LinkedHashMap<>();

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDriver.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDriver.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 
 public class LibSqlDriver implements Driver {
 
@@ -42,18 +41,7 @@ public class LibSqlDriver implements Driver {
 
     @Override
     public Connection connect(String url, Properties info) throws SQLException {
-        Matcher matcher = LibSqlConstants.CONNECTION_URL_PATTERN.matcher(url);
-        if (!matcher.matches()) {
-            throw new LibSqlException(
-                "Invalid connection URL: " + url +
-                ".\nExpected URL formats: " + LibSqlConstants.CONNECTION_URL_EXAMPLES);
-        }
-
-        String targetUrl = url.replaceFirst("jdbc:dbeaver:libsql:", "");
-        if (targetUrl.startsWith("libsql://")) {
-            targetUrl = targetUrl.replaceFirst("libsql://", "https://");
-        }
-
+        String targetUrl = LibSqlUtils.validateAndFormatUrl(url);
         Map<String, Object> props = new LinkedHashMap<>();
         for (Enumeration<?> pne = info.propertyNames(); pne.hasMoreElements(); ) {
             String propName = (String) pne.nextElement();

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlUtils.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlUtils.java
@@ -16,6 +16,8 @@
  */
 package com.dbeaver.jdbc.driver.libsql;
 
+import org.jkiss.code.NotNull;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -68,7 +70,8 @@ public class LibSqlUtils {
         }
     }
 
-    public static String validateAndFormatUrl(String url) throws LibSqlException {
+    @NotNull
+    public static String validateAndFormatUrl(@NotNull String url) throws LibSqlException {
         Matcher matcher = LibSqlConstants.CONNECTION_URL_PATTERN.matcher(url);
         if (!matcher.matches()) {
             throw new LibSqlException(

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlUtils.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlUtils.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.regex.Matcher;
 
 public class LibSqlUtils {
 
@@ -65,5 +66,21 @@ public class LibSqlUtils {
         try (Statement stat = connection.createStatement()) {
             return stat.executeQuery(query);
         }
+    }
+
+    public static String validateAndFormatUrl(String url) throws LibSqlException {
+        Matcher matcher = LibSqlConstants.CONNECTION_URL_PATTERN.matcher(url);
+        if (!matcher.matches()) {
+            throw new LibSqlException(
+                "Invalid connection URL: " + url +
+                    ".\nExpected URL formats: " + LibSqlConstants.CONNECTION_URL_EXAMPLES
+            );
+        }
+
+        String formattedUrl = url.replaceFirst("jdbc:dbeaver:libsql:", "");
+        if (formattedUrl.startsWith("libsql://")) {
+            formattedUrl = formattedUrl.replaceFirst("libsql://", "https://");
+        }
+        return formattedUrl;
     }
 }

--- a/com.dbeaver.jdbc.driver.libsql/src/test/java/com/dbeaver/jdbc/upd/driver/test/LibSqlUtilsTest.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/test/java/com/dbeaver/jdbc/upd/driver/test/LibSqlUtilsTest.java
@@ -25,8 +25,10 @@ public class LibSqlUtilsTest {
 
     @Test
     public void testFormatUrl() throws LibSqlException {
-        assertFormatError("localhost");
-        assertFormatError("libsql://9M7NAcHfxSZyIm#*yxLY");
+        Assert.assertThrows(
+            LibSqlException.class,
+            () -> LibSqlUtils.validateAndFormatUrl("localhost")
+        );
 
         assertUrlFormat("jdbc:dbeaver:libsql:http://localhost", "http://localhost");
         assertUrlFormat("jdbc:dbeaver:libsql:https://localhost", "https://localhost");
@@ -38,19 +40,5 @@ public class LibSqlUtilsTest {
 
     private void assertUrlFormat(String input, String expected) throws LibSqlException {
         Assert.assertEquals(expected, LibSqlUtils.validateAndFormatUrl(input));
-    }
-
-    private void assertFormatError(String input) {
-        String expectedMessage = "Invalid connection URL: " + input +
-            ".\nExpected URL formats: jdbc:dbeaver:libsql:<hostname>, libsql://<hostname>";
-        try {
-            LibSqlUtils.validateAndFormatUrl(input);
-            Assert.fail("Expected exception: " + expectedMessage);
-        } catch (LibSqlException e) {
-            Assert.assertEquals(
-                expectedMessage,
-                e.getMessage()
-            );
-        }
     }
 }

--- a/com.dbeaver.jdbc.driver.libsql/src/test/java/com/dbeaver/jdbc/upd/driver/test/LibSqlUtilsTest.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/test/java/com/dbeaver/jdbc/upd/driver/test/LibSqlUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp
+ *
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of DBeaver Corp and its suppliers, if any.
+ * The intellectual and technical concepts contained
+ * herein are proprietary to DBeaver Corp and its suppliers
+ * and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from DBeaver Corp.
+ */
+package com.dbeaver.jdbc.upd.driver.test;
+
+import com.dbeaver.jdbc.driver.libsql.LibSqlException;
+import com.dbeaver.jdbc.driver.libsql.LibSqlUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LibSqlUtilsTest {
+
+    @Test
+    public void testFormatUrl() throws LibSqlException {
+        assertFormatError("localhost");
+        assertFormatError("libsql://9M7NAcHfxSZyIm#*yxLY");
+
+        assertUrlFormat("jdbc:dbeaver:libsql:http://localhost", "http://localhost");
+        assertUrlFormat("jdbc:dbeaver:libsql:https://localhost", "https://localhost");
+        assertUrlFormat("jdbc:dbeaver:libsql:http://localhost:8080", "http://localhost:8080");
+        assertUrlFormat("jdbc:dbeaver:libsql:libsql://localhost", "https://localhost");
+        assertUrlFormat("libsql://turso.url.my-hostname-1", "https://turso.url.my-hostname-1");
+        assertUrlFormat("libsql://turso.url.my-hostname-1:8080", "https://turso.url.my-hostname-1:8080");
+    }
+
+    private void assertUrlFormat(String input, String expected) throws LibSqlException {
+        Assert.assertEquals(expected, LibSqlUtils.validateAndFormatUrl(input));
+    }
+
+    private void assertFormatError(String input) {
+        String expectedMessage = "Invalid connection URL: " + input +
+            ".\nExpected URL formats: jdbc:dbeaver:libsql:<hostname>, libsql://<hostname>";
+        try {
+            LibSqlUtils.validateAndFormatUrl(input);
+            Assert.fail("Expected exception: " + expectedMessage);
+        } catch (LibSqlException e) {
+            Assert.assertEquals(
+                expectedMessage,
+                e.getMessage()
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixed the url parsing when providing protocol in server url and/or using ports
(default protocol is still https)