### PR TITLE
dbeaver/dbeaver-jdbc-libsql#17 Added turso urls support

### DIFF
--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConstants.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import java.util.regex.Pattern;
 
 public class LibSqlConstants {
 
-    public static final Pattern CONNECTION_URL_EXAMPLE = Pattern.compile("jdbc:dbeaver:libsql:<server-url>");
-    public static final Pattern CONNECTION_URL_PATTERN = Pattern.compile("jdbc:dbeaver:libsql:(.+)");
+    public static final String CONNECTION_URL_EXAMPLES = "jdbc:dbeaver:libsql:<server-url>, libsql://";
+    public static final Pattern CONNECTION_URL_PATTERN = Pattern.compile("(jdbc:dbeaver:libsql:|libsql://)(.+)");
 
     public static final int DRIVER_VERSION_MAJOR = 1;
     public static final int DRIVER_VERSION_MINOR = 0;

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDriver.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDriver.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
 
 public class LibSqlDriver implements Driver {
 
@@ -42,13 +41,7 @@ public class LibSqlDriver implements Driver {
 
     @Override
     public Connection connect(String url, Properties info) throws SQLException {
-        Matcher matcher = LibSqlConstants.CONNECTION_URL_PATTERN.matcher(url);
-        if (!matcher.matches()) {
-            throw new LibSqlException(
-                "Invalid connection URL: " + url +
-                ".\nExpected URL format: " + LibSqlConstants.CONNECTION_URL_EXAMPLE);
-        }
-        String targetUrl = matcher.group(1);
+        String targetUrl = LibSqlUtils.validateAndFormatUrl(url);
 
         Map<String, Object> props = new LinkedHashMap<>();
         for (Enumeration<?> pne = info.propertyNames(); pne.hasMoreElements(); ) {

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlUtils.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlUtils.java
@@ -80,12 +80,13 @@ public class LibSqlUtils {
             );
         }
 
-        if (url.startsWith("jdbc:dbeaver:libsql:")) {
-            url = url.replaceFirst("jdbc:dbeaver:libsql:", "");
+        String formattedUrl = url;
+        if (formattedUrl.startsWith("jdbc:dbeaver:libsql:")) {
+            formattedUrl = formattedUrl.replaceFirst("jdbc:dbeaver:libsql:", "");
         }
-        if (url.startsWith("libsql://")) {
-            url = url.replaceFirst("libsql://", "https://");
+        if (formattedUrl.startsWith("libsql://")) {
+            formattedUrl = formattedUrl.replaceFirst("libsql://", "https://");
         }
-        return url;
+        return formattedUrl;
     }
 }

--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlUtils.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlUtils.java
@@ -1,6 +1,6 @@
 /*
  * DBeaver - Universal Database Manager
- * Copyright (C) 2010-2024 DBeaver Corp and others
+ * Copyright (C) 2010-2025 DBeaver Corp and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
  */
 package com.dbeaver.jdbc.driver.libsql;
 
+import org.jkiss.code.NotNull;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.regex.Matcher;
 
 public class LibSqlUtils {
 
@@ -65,5 +68,24 @@ public class LibSqlUtils {
         try (Statement stat = connection.createStatement()) {
             return stat.executeQuery(query);
         }
+    }
+
+    @NotNull
+    public static String validateAndFormatUrl(@NotNull String url) throws LibSqlException {
+        Matcher matcher = LibSqlConstants.CONNECTION_URL_PATTERN.matcher(url);
+        if (!matcher.matches()) {
+            throw new LibSqlException(
+                "Invalid connection URL: " + url +
+                    ".\nExpected URL formats: " + LibSqlConstants.CONNECTION_URL_EXAMPLES
+            );
+        }
+
+        if (url.startsWith("jdbc:dbeaver:libsql:")) {
+            url = url.replaceFirst("jdbc:dbeaver:libsql:", "");
+        }
+        if (url.startsWith("libsql://")) {
+            url = url.replaceFirst("libsql://", "https://");
+        }
+        return url;
     }
 }

--- a/com.dbeaver.jdbc.driver.libsql/src/test/java/com/dbeaver/jdbc/upd/driver/test/LibSqlUtilsTest.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/test/java/com/dbeaver/jdbc/upd/driver/test/LibSqlUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * DBeaver - Universal Database Manager
+ * Copyright (C) 2010-2025 DBeaver Corp
+ *
+ * All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of DBeaver Corp and its suppliers, if any.
+ * The intellectual and technical concepts contained
+ * herein are proprietary to DBeaver Corp and its suppliers
+ * and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from DBeaver Corp.
+ */
+package com.dbeaver.jdbc.upd.driver.test;
+
+import com.dbeaver.jdbc.driver.libsql.LibSqlException;
+import com.dbeaver.jdbc.driver.libsql.LibSqlUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LibSqlUtilsTest {
+
+    @Test
+    public void testFormatUrl() throws LibSqlException {
+        Assert.assertThrows(
+            LibSqlException.class,
+            () -> LibSqlUtils.validateAndFormatUrl("localhost")
+        );
+        Assert.assertThrows(
+            LibSqlException.class,
+            () -> LibSqlUtils.validateAndFormatUrl("http://localhost")
+        );
+
+        assertUrlFormat("jdbc:dbeaver:libsql:http://localhost", "http://localhost");
+        assertUrlFormat("jdbc:dbeaver:libsql:https://localhost", "https://localhost");
+        assertUrlFormat("jdbc:dbeaver:libsql:http://localhost:8080", "http://localhost:8080");
+        assertUrlFormat("jdbc:dbeaver:libsql:libsql://localhost", "https://localhost");
+        assertUrlFormat("libsql://turso.url.my-hostname-1", "https://turso.url.my-hostname-1");
+        assertUrlFormat("libsql://turso.url.my-hostname-1:8080", "https://turso.url.my-hostname-1:8080");
+    }
+
+    private void assertUrlFormat(String input, String expected) throws LibSqlException {
+        Assert.assertEquals(expected, LibSqlUtils.validateAndFormatUrl(input));
+    }
+}


### PR DESCRIPTION
Added support for `libsql` urls generated by turso:
<img width="669" height="259" alt="image" src="https://github.com/user-attachments/assets/ff8d41d4-8bf3-49a1-a7cb-5d0fee02501b" />
