### PR TITLE
[Release] dbeaver-jdbc-libsql version bump to 1.0.7-SNAPSHOT

### DIFF
--- a/com.dbeaver.jdbc.driver.libsql/META-INF/MANIFEST.MF
+++ b/com.dbeaver.jdbc.driver.libsql/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: DBeaver LibSQL JDBC Driver
 Bundle-SymbolicName: com.dbeaver.jdbc.driver.libsql
-Bundle-Version: 1.0.6.qualifier
+Bundle-Version: 1.0.7.qualifier
 Bundle-Release-Date: 20230522
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/com.dbeaver.jdbc.driver.libsql/pom.xml
+++ b/com.dbeaver.jdbc.driver.libsql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.dbeaver.jdbc</groupId>
         <artifactId>jdbc-libsql</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>com.dbeaver.jdbc.driver.libsql</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.dbeaver.jdbc</groupId>
     <artifactId>jdbc-libsql</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>DBeaver LibSQL JDBC Project</name>
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.dbeaver.common</groupId>
         <artifactId>com.dbeaver.common.main</artifactId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.7.0-SNAPSHOT</version>
         <relativePath>../dbeaver-common</relativePath>
     </parent>
 


### PR DESCRIPTION
Increment version after 1.0.6 release. Resolves dbeaver/pro#7752