### PR TITLE
Fix #20: implement Connection.isValid() and track close state

### DIFF
--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConnection.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlConnection.java
@@ -28,6 +28,10 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class LibSqlConnection extends AbstractJdbcConnection {
 
@@ -40,6 +44,7 @@ public class LibSqlConnection extends AbstractJdbcConnection {
     @NotNull
     private final Map<String, Object> driverProperties;
     private LibSqlDatabaseMetaData databaseMetaData;
+    private volatile boolean closed = false;
 
     public LibSqlConnection(
         @NotNull LibSqlDriver driver,
@@ -108,12 +113,47 @@ public class LibSqlConnection extends AbstractJdbcConnection {
 
     @Override
     public void close() throws SQLException {
-        client.close();
+        if (!closed) {
+            client.close();
+            closed = true;
+        }
     }
 
     @Override
     public boolean isClosed() {
-        return false;
+        return closed;
+    }
+
+    @Override
+    public boolean isValid(int timeout) throws SQLException {
+        if (timeout < 0) {
+            throw new SQLException("Invalid timeout value: " + timeout);
+        }
+        if (closed) {
+            return false;
+        }
+        CompletableFuture<Boolean> ping = CompletableFuture.supplyAsync(() -> {
+            try {
+                LibSqlUtils.executeQuery(this, "SELECT 1");
+                return Boolean.TRUE;
+            } catch (Exception e) {
+                return Boolean.FALSE;
+            }
+        });
+        try {
+            if (timeout == 0) {
+                return ping.get();
+            }
+            return ping.get(timeout, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            ping.cancel(true);
+            return false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (ExecutionException e) {
+            return false;
+        }
     }
 
     @Override

--- a/com.dbeaver.jdbc.driver.libsql/src/test/java/com/dbeaver/jdbc/upd/driver/test/LibSqlDriverTest.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/test/java/com/dbeaver/jdbc/upd/driver/test/LibSqlDriverTest.java
@@ -35,6 +35,14 @@ public class LibSqlDriverTest {
                 System.out.println("Driver: " + metaData.getDriverName());
                 System.out.println("Database: " + metaData.getDatabaseProductName() + " " + metaData.getDatabaseProductVersion());
 
+                System.out.println("isValid(5) = " + connection.isValid(5));
+                try {
+                    connection.isValid(-1);
+                    System.out.println("BUG: negative timeout did not throw");
+                } catch (SQLException e) {
+                    System.out.println("isValid(-1) correctly threw: " + e.getMessage());
+                }
+
                 System.out.println("Query:");
                 try (Statement dbStat = connection.createStatement()) {
                     try (ResultSet dbResult = dbStat.executeQuery("select * from testme")) {
@@ -61,6 +69,8 @@ public class LibSqlDriverTest {
                     }
                 }
 
+                connection.close();
+                System.out.println("isValid(5) after close = " + connection.isValid(5));
             }
         } finally {
             System.out.println("Finished (" + (System.currentTimeMillis() - startTime) + "ms)");


### PR DESCRIPTION
Fixes #20.

`LibSqlConnection` previously inherited the no-op `isValid()` from `AbstractJdbcConnection`, which throws `SQLFeatureNotSupportedException`. This breaks HikariCP / Spring Boot pool validation and causes JetBrains DataGrip / PyCharm to hang for ~50 s after every query while waiting for the unanswered validation call.

Three coupled changes, all in `LibSqlConnection`:

1. **`closed` state field.** `isClosed()` previously returned hardcoded `false` and `close()` didn't track state. A correct `isValid()` must short-circuit when the connection is closed, so the close flag has to come along.
2. **`isValid(int timeout)` override.** Runs `SELECT 1` via the same `LibSqlUtils.executeQuery` path the constructor already uses to verify the connection. Wrapped in a `CompletableFuture` so the spec-mandated timeout actually applies (`get(timeout, SECONDS)` for `timeout > 0`, blocking `get()` for `timeout == 0`). Returns `false` (does not throw) on any HTTP / SQL failure, per the JDBC contract that `isValid()` is a predicate.
3. **`timeout < 0` ? `SQLException`** per the JDBC spec.

### Verified
`mvn -f aggregate/pom.xml package` and `... test` both pass.

Manual integration run against Turso:
- `isValid(5)` ? `true`
- `isValid(0)` ? `true`
- `isValid(-1)` ? throws `SQLException("Invalid timeout value: -1")`
- `isClosed()` ? `false` before close, `true` after
- `isValid(5)` after close ? `false`

`LibSqlDriverTest.main()` was extended with two of those assertions.