### PR TITLE
LibSqlClient.openSimpleConnection: include Bearer auth token

### DIFF
--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/client/LibSqlClient.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/client/LibSqlClient.java
@@ -164,6 +164,9 @@ public class LibSqlClient {
         baseURL += endpoint;
         HttpURLConnection connection = (HttpURLConnection) new URL(baseURL).openConnection();
         connection.setRequestProperty(HttpConstants.HEADER_USER_AGENT, userAgent);
+        if (!CommonUtils.isEmpty(authToken)) {
+            connection.setRequestProperty(HttpConstants.HEADER_AUTHORIZATION, "Bearer " + authToken);
+        }
         return connection;
     }
 


### PR DESCRIPTION
`LibSqlClient.executeBatch` includes the `Authorization: Bearer <token>` header when an auth token is configured, but `openSimpleConnection` (used by `LibSqlDatabaseMetaData.readServerVersion` to hit `/version`) does not. Against any libSQL server that requires authentication on every request (notably Turso's managed service) this returns **401 Unauthorized**, so `getDatabaseProductName()` / `getDatabaseProductVersion()` fail.

Reproduction (Turso):

```bash
curl -i https://<turso-host>/version
# HTTP/1.1 401 Unauthorized
curl -i -H "Authorization: Bearer $TOKEN" https://<turso-host>/version
# HTTP/1.1 200 OK   (or 404 ? see follow-up PR for the 404 path)
```

Fix: mirror `executeBatch`'s auth-header logic in `openSimpleConnection`.