### PR TITLE
Fall back to 'SQLite' when /version endpoint is unavailable

### DIFF
--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDatabaseMetaData.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlDatabaseMetaData.java
@@ -52,7 +52,11 @@ public class LibSqlDatabaseMetaData extends AbstractJdbcDatabaseMetaData<LibSqlC
                 serverVersion = IOUtils.readLine(is);
             }
         } catch (IOException e) {
-            throw new SQLException(e);
+            // Some libSQL providers (e.g. Turso's managed service) don't
+            // expose a /version endpoint. Fall back to a static product
+            // name so JDBC clients can still classify the database as
+            // SQLite-compatible and pick a sensible dialect.
+            serverVersion = "SQLite";
         }
     }
 


### PR DESCRIPTION
Turso's managed libSQL service does not expose a `/version` endpoint at all:

```bash
curl -H "Authorization: Bearer $TOKEN" https://<turso-host>/version
# HTTP/1.1 404 Not Found
# {"error":"route not found: [\"version\"]"}
```

`LibSqlDatabaseMetaData.readServerVersion` propagates the resulting `IOException` as `SQLException`, so `getDatabaseProductName()` throws. Clients that rely on the product name to pick a SQL dialect (JetBrains DataGrip / PyCharm in particular) classify the connection as `UNKNOWN`, which downstream causes a hang on result-set finalization.

Fix: when `/version` is unreachable, fall back to a static `"SQLite"` product name. libSQL is SQLite-compatible at the SQL level, so this gives clients a sensible dialect to pick. If `/version` is reachable (self-hosted product name. libSQL is SQLite-compatible at the SQL level, so this gives clients a sensible dialect to pick. If `/version` is reachable (self-hosted sqld), the actual server version is used as before.