### PR TITLE
Fix Statement.getUpdateCount: return -1 when current result is a ResultSet

### DIFF
--- a/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlStatement.java
+++ b/com.dbeaver.jdbc.driver.libsql/src/main/java/com/dbeaver/jdbc/driver/libsql/LibSqlStatement.java
@@ -121,7 +121,10 @@ public class LibSqlStatement extends AbstractJdbcStatement<LibSqlConnection> {
     @Override
     public int getUpdateCount() throws SQLException {
         if (executionResult == null) {
-            throw new LibSqlException("No update count before statement execute");
+            return -1;
+        }
+        if (executionResult.getColumns() != null && !executionResult.getColumns().isEmpty()) {
+            return -1;
         }
         return (int) executionResult.getUpdateCount();
     }
@@ -129,13 +132,18 @@ public class LibSqlStatement extends AbstractJdbcStatement<LibSqlConnection> {
     @Override
     public long getLargeUpdateCount() throws SQLException {
         if (executionResult == null) {
-            throw new LibSqlException("No update count before statement execute");
+            return -1;
+        }
+        if (executionResult.getColumns() != null && !executionResult.getColumns().isEmpty()) {
+            return -1;
         }
         return executionResult.getUpdateCount();
     }
 
     @Override
     public boolean getMoreResults() throws SQLException {
+        executionResult = null;
+        resultSet = null;
         return false;
     }
 
@@ -151,6 +159,8 @@ public class LibSqlStatement extends AbstractJdbcStatement<LibSqlConnection> {
 
     @Override
     public boolean getMoreResults(int current) throws SQLException {
+        executionResult = null;
+        resultSet = null;
         return false;
     }
     @Override


### PR DESCRIPTION
`LibSqlStatement.getUpdateCount()` currently returns `rows_written` unconditionally, including for `SELECT` queries where `rows_written == 0`.

Per the JDBC spec:
> Retrieves the current result as an update count; if the result is a `ResultSet` object **or there are no more results, -1 is returned**.

Returning `0` instead of `-1` for a SELECT means "an update result with 0 rows affected" ? a different, legitimate state. Clients that walk all results via the standard pattern loop forever:

```kotlin
do {
    val isRs = stmt.getMoreResults()
    val n = stmt.getUpdateCount()
    if (!isRs && n == -1) break
    // ...
} while (true)
```

This manifests in JetBrains DataGrip / PyCharm as the query showing rows in the editor but the "loading" spinner never stopping. Eventually the RMI proxy backing the Statement is GC'd on the driver side and the IDE log fills with `java.rmi.NoSuchObjectException: no such object in table` from `UniversalResultsProducer$StatementSource.hasMoreResultSets` / `getUpdateCount`.

Fix:

- `getUpdateCount` / `getLargeUpdateCount` return `-1` when the current result is a ResultSet (signalled by `executionResult.getColumns()` being non-empty) or when there is no current result.
- `getMoreResults()` (both overloads) clears `executionResult` and `resultSet` so subsequent `getUpdateCount` correctly returns `-1` for "no more results".
- Removed `LibSqlException("No update count before statement execute")` ? per spec, `getUpdateCount` returns `-1` in that state, it does not throw.