### PR TITLE
dbeaver/pro#10477 Optimize bundle dependencies

### DIFF
--- a/com.dbeaver.jdbc.driver.libsql/META-INF/MANIFEST.MF
+++ b/com.dbeaver.jdbc.driver.libsql/META-INF/MANIFEST.MF
@@ -8,8 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: com.dbeaver.jdbc.driver.libsql,
  com.dbeaver.jdbc.driver.libsql.client
-Require-Bundle: com.dbeaver.jdbc.api,
- org.jkiss.utils,
- com.google.gson
+Require-Bundle: com.dbeaver.jdbc.api;visibility:=reexport,
+ org.jkiss.utils
 Bundle-Vendor: DBeaver Corp
 Automatic-Module-Name: com.dbeaver.jdbc.driver.libsql


### PR DESCRIPTION
Closes dbeaver/pro#10477

## Summary
- remove transitively redundant OSGi bundle requirements
- re-export the JDBC API dependency exposed through implementation classes

## Testing
- covered by the CloudBeaver CE aggregate package build
- `git diff --check`

This PR was generated with AI assistance.